### PR TITLE
特定キーワードでなく、常に外部ブラウザを起動するように

### DIFF
--- a/Android-Sample/app/src/main/assets/sample.html
+++ b/Android-Sample/app/src/main/assets/sample.html
@@ -21,7 +21,7 @@
     <script type="text/javascript" src="xxx.js"></script>
 
     <!-- 設定したRTBパラメータをデバッグ出力するタグ -->
-    <script type="text/javascript" src="https://js.gsspcln.jp/l/jssdk_debug.js"></script>
+    <script type='text/javascript' src='https://js.gsspcln.jp/l/jssdk_debug.js'></script>
 
 </body>
 </html>

--- a/Android-Sample/app/src/main/assets/sample.html
+++ b/Android-Sample/app/src/main/assets/sample.html
@@ -21,7 +21,7 @@
     <script type="text/javascript" src="xxx.js"></script>
 
     <!-- 設定したRTBパラメータをデバッグ出力するタグ -->
-    <script type='text/javascript' src='https://js.gsspcln.jp/l/jssdk_debug.js'></script>
+    <script type="text/javascript" src="https://js.gsspcln.jp/l/jssdk_debug.js"></script>
 
 </body>
 </html>

--- a/Android-Sample/app/src/main/assets/sample.html
+++ b/Android-Sample/app/src/main/assets/sample.html
@@ -21,7 +21,8 @@
     <script type="text/javascript" src="xxx.js"></script>
 
     <!-- 設定したRTBパラメータをデバッグ出力するタグ -->
-    <script type='text/javascript' src='http://js.gsspcln.jp/l/jssdk_debug.js'></script>
+    <script type='text/javascript' src='https://js.gsspcln.jp/l/jssdk_debug.js'></script>
 
 </body>
 </html>
+

--- a/Android-Sample/app/src/main/java/jp/co/geniee/sample/ad/js/MainActivity.java
+++ b/Android-Sample/app/src/main/java/jp/co/geniee/sample/ad/js/MainActivity.java
@@ -1,13 +1,16 @@
 package jp.co.geniee.sample.ad.js;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.Log;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -44,23 +47,19 @@ public class MainActivity extends AppCompatActivity {
         // 広告はiFrame内に表示されるケースがあります。
         // この対応を行わないとiFrame内に広告クリック先のページが表示されます。
         webView.setWebViewClient(new WebViewClient() {
-
             @Override
-            public void onLoadResource(WebView view, String url) {
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                view.getContext().startActivity(intent);
+                return true;
+            };
 
-                // URLにキーワードが含まれていたら 広告がクリックされたと判断
-                if (url.contains("管理ツールで設定したキーワード")) {
-                    // 外部ブラウザで開くのでWebView内での読み込みを中断します。
-                    webView.stopLoading();
-
-                    // 外部ブラウザで開きます。
-                    Uri uri = Uri.parse(url);
-                    Intent i = new Intent(Intent.ACTION_VIEW, uri);
-                    startActivity(i);
-                    return;
-                }
-
-                super.onLoadResource(view, url);
+            @TargetApi(Build.VERSION_CODES.N)
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
+                view.getContext().startActivity(intent);
+                return true;
             }
         });
 

--- a/Android-Sample/app/src/main/java/jp/co/geniee/sample/ad/js/MainActivity.java
+++ b/Android-Sample/app/src/main/java/jp/co/geniee/sample/ad/js/MainActivity.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-import android.util.Log;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;

--- a/iOS-Samples/WKWebViewSample/WKWebViewSample/ViewController.m
+++ b/iOS-Samples/WKWebViewSample/WKWebViewSample/ViewController.m
@@ -84,11 +84,10 @@
     NSURL *url = navigationAction.request.URL;
     NSString *urlString = [url absoluteString];
 
-    // URLに外部ブラウザで起動するためのキーワードが含まれていたら外部ブラウザで開く処理
-    // (広告に管理画面で設定したキーワードが設定され、広告をタップすると外部ブラウザで開く処理を実現する)
-    // 下の例の、@"外部ブラウザ起動用キーワード"を登録済みのものに書き換える。
+    // URLが空でない場合、外部ブラウザで起動する
+    // 広告をタップすると外部ブラウザで開く
     if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
-        if ([urlString rangeOfString:@"外部ブラウザ起動用キーワード"].location != NSNotFound) {
+        if (urlString != nil && [urlString length] > 0) {
             [[UIApplication sharedApplication] openURL:url options:@{}
                                      completionHandler:nil];
             decisionHandler(WKNavigationActionPolicyCancel);

--- a/iOS-Samples/WKWebViewSample/WKWebViewSample/test.html
+++ b/iOS-Samples/WKWebViewSample/WKWebViewSample/test.html
@@ -2,7 +2,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <head>
         <!-- デバッグ出力の設定。IDFAなどのパラメータが正しく設定されていたらコンソールログに出力されます。-->
-        <script type='text/javascript' src='https://js.gsspcln.jp/l/jssdk_debug.js'></script>
+        <script type="text/javascript" src="https://js.gsspcln.jp/l/jssdk_debug.js"></script>
     </head>
     <body>
         

--- a/iOS-Samples/WKWebViewSample/WKWebViewSample/test.html
+++ b/iOS-Samples/WKWebViewSample/WKWebViewSample/test.html
@@ -2,7 +2,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <head>
         <!-- デバッグ出力の設定。IDFAなどのパラメータが正しく設定されていたらコンソールログに出力されます。-->
-        <script type="text/javascript" src="http://js.gsspcln.jp/l/jssdk_debug.js"></script>
+        <script type='text/javascript' src='https://js.gsspcln.jp/l/jssdk_debug.js'></script>
     </head>
     <body>
         


### PR DESCRIPTION
# check
* [x] android7.0(N)未満でも常にブラウザが開くこと
* [x] android7.0(N)以後でも常にブラウザが開くこと
* [x] iosでも常にブラウザが開くこと

# issue
https://github.com/geniee-ssp/Geniee-JavaScript-SDK/issues/14
